### PR TITLE
Workaround for removal of unneeded JDK11 deps brought on JDK8 image 

### DIFF
--- a/os-jws-prometheus/run
+++ b/os-jws-prometheus/run
@@ -7,6 +7,10 @@ ADDED_DIR="$SCRIPT_DIR/added"
 
 # install prometheus-jmx-exporter
 dnf install -y prometheus-jmx-exporter
+# prometheus-jmx-exporter installs additional unneeded dependencies on jdk8 image, so we remove them
+if [ -n "$(yum list installed java-1.8.0-openjdk-devel |grep java-1.8.0-openjdk-devel)" ]; then
+    rpm -e --nodeps java-11-openjdk-headless prometheus-jmx-exporter-openjdk11
+fi
 dnf clean all
 
 # copy the configuration for JWS


### PR DESCRIPTION
This adds a check in order to remove packages that are brought as a dependency of openjdk11 on openjdk8 image.