### PR TITLE
Follow up to #22 to cover JDK21 image's case

### DIFF
--- a/os-jws-prometheus/run
+++ b/os-jws-prometheus/run
@@ -7,8 +7,8 @@ ADDED_DIR="$SCRIPT_DIR/added"
 
 # install prometheus-jmx-exporter
 dnf install -y prometheus-jmx-exporter
-# prometheus-jmx-exporter installs additional unneeded dependencies on jdk8 and jdk17 images, so we remove them
-if [ -n "$(yum list installed java-1.8.0-openjdk-devel |grep java-1.8.0-openjdk-devel)" ] || [ -n "$(yum list installed java-17-openjdk-devel |grep java-17-openjdk-devel)" ]; then
+# prometheus-jmx-exporter installs additional unneeded dependencies on jdk8, jdk17 and jdk21 images, so we remove them
+if [ -n "$(yum list installed java-1.8.0-openjdk-devel |grep java-1.8.0-openjdk-devel)" ] || [ -n "$(yum list installed java-17-openjdk-devel |grep java-17-openjdk-devel)" ] || [ -n "$(yum list installed java-21-openjdk-devel |grep java-21-openjdk-devel)" ]; then
     rpm -e --nodeps java-11-openjdk-headless prometheus-jmx-exporter-openjdk11
 fi
 dnf clean all


### PR DESCRIPTION
This expands the fix for removing unneeded dependencies' fix for JDK21 image.